### PR TITLE
Added support for salt

### DIFF
--- a/tiny-enigma.h
+++ b/tiny-enigma.h
@@ -55,6 +55,7 @@ public:
     
     // get methods
     QByteArray key();
+    QByteArray salt();
     QByteArray iv();
     
     // encrypt a whole file
@@ -67,6 +68,7 @@ public slots:
 
 private:
     unsigned char *m_key = nullptr;
+    QByteArray m_salt;
     unsigned char *m_iv = nullptr;
     EVP_CIPHER_CTX *m_ctx = nullptr;
 
@@ -76,6 +78,8 @@ private:
     void initCtx();
     // generate iv
     QByteArray generateIV();
+    // generate salt, uses generateIV()
+    QByteArray generateSalt();
     // derive key from password
     QByteArray deriveKey(QString &password);
 };


### PR DESCRIPTION
`QByteArray TinyEnigma::deriveKey(QString &password)` uses an immediately (on construction) generated salt. That salt is generated the same way as the iv. Therefore it uses `QByteArray generateSalt() ` which makes use of `QByteArray generateIV()`. The key salt can be returned by the new `QByteArray salt()` member.